### PR TITLE
🐛 Fix local scope formatter for empty functions

### DIFF
--- a/c_formatter_42/formatters/helper.py
+++ b/c_formatter_42/formatters/helper.py
@@ -25,11 +25,17 @@ def locally_scoped(func):
     """ Apply the formatter on every local scopes of the content """
 
     def wrapper(content: str) -> str:
+        def get_repl(match):
+            body = match.group("body").strip("\n")
+            result = func(body)
+            is_empty = result.strip() == ""
+            return ")\n{" + ("\n" + result if not is_empty else "") + "\n}\n"
+
         return re.sub(
             # `*?` is the non greedy version of `*`
             # https://docs.python.org/3/howto/regex.html#greedy-versus-non-greedy
-            r"\)\n\{\n(?P<body>.*?)\n\}\n".replace(r"\n", "\n"),
-            lambda match: ")\n{\n" + func(match.group("body")) + "\n}\n",
+            r"\)\n\{(?P<body>.*?)\n\}\n".replace(r"\n", "\n"),
+            lambda match: get_repl(match),
             content,
             flags=re.DOTALL
         )

--- a/c_formatter_42/formatters/helper.py
+++ b/c_formatter_42/formatters/helper.py
@@ -25,17 +25,18 @@ def locally_scoped(func):
     """ Apply the formatter on every local scopes of the content """
 
     def wrapper(content: str) -> str:
-        def get_repl(match):
+        def get_replacement(match):
             body = match.group("body").strip("\n")
             result = func(body)
-            is_empty = result.strip() == ""
-            return ")\n{" + ("\n" + result if not is_empty else "") + "\n}\n"
+            if result.strip() == "":
+                return ")\n{\n}\n"
+            return ")\n{\n" + result + "\n}\n"
 
         return re.sub(
             # `*?` is the non greedy version of `*`
             # https://docs.python.org/3/howto/regex.html#greedy-versus-non-greedy
             r"\)\n\{(?P<body>.*?)\n\}\n".replace(r"\n", "\n"),
-            lambda match: get_repl(match),
+            get_replacement,
             content,
             flags=re.DOTALL
         )

--- a/c_formatter_42/formatters/line_breaker.py
+++ b/c_formatter_42/formatters/line_breaker.py
@@ -4,7 +4,7 @@ from c_formatter_42.formatters import helper
 
 def line_breaker(content: str, column_limit: int = 80) -> str:
     lines = content.split("\n")
-    lines = list(map(lambda s: insert_break(s, column_limit), lines))
+    lines = [insert_break(line, column_limit) for line in lines]
 
     return "\n".join(lines)
 

--- a/tests/formatters/test_hoist.py
+++ b/tests/formatters/test_hoist.py
@@ -3,7 +3,8 @@
 #                                                         :::      ::::::::    #
 #    test_hoist.py                                      :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: cacharle <me@cacharle.xyz>                 +#+  +:+       +#+         # +#+#+#+#+#+   +#+            #
+#    By: cacharle <me@cacharle.xyz>                 +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/10/04 12:29:07 by cacharle          #+#    #+#              #
 #    Updated: 2021/02/11 22:16:57 by charles          ###   ########.fr        #
 #                                                                              #
@@ -144,6 +145,53 @@ void foo()
 \tt_list\t*bar = (t_list *)malloc(sizeof(t_list) * (count_elements(baz) + 1));
 }
 """)
+
+
+def test_hoist_empty_function():
+    input = """
+void empty_function(void)
+{
+}
+
+int **function()
+{
+\tint **tab = malloc(4 * sizeof(int *));
+\tint i = -1;
+\twhile (++i < 4)
+\t{
+\t\ttab[i] = malloc(4 * sizeof(int));
+\t\tint j = -1;
+\t\twhile (++j < 4)
+\t\t\ttab[i][j] = i * j;
+\t}
+\treturn (tab);
+}
+"""
+    output = """
+void empty_function(void)
+{
+}
+
+int **function()
+{
+\tint\t**tab;
+\tint\ti;
+\tint\tj;
+
+\ttab = malloc(4 * sizeof(int *));
+\ti = -1;
+\twhile (++i < 4)
+\t{
+\t\ttab[i] = malloc(4 * sizeof(int));
+\t\tj = -1;
+\t\twhile (++j < 4)
+\t\t\ttab[i][j] = i * j;
+\t}
+\treturn (tab);
+}
+"""
+    assert output == hoist(input)
+
 
 @pytest.mark.skip()
 def test_hoist_array():


### PR DESCRIPTION
### Fixed

The regular expression used to retrieve the body of a function in `helper.py/locally_scoped` does not work with empty functions.

### Example

Base test file:

```c
void empty_function()
{
}

int **function()
{
    int **tab = malloc(4 * sizeof(int *));
    int i = -1;
    while (++i < 4)
    {
        tab[i] = malloc(4 * sizeof(int));
        int j = -1;
        while (++j < 4)
            tab[i][j] = i * j;
    }
    return tab;
}
```

Without the fix, variables from `function` are hoisted in `empty_function` (error):

```c
void	empty_function(void)
{
	int	**tab;
	int	i;
	int	j;

}
int	**function()
{
	tab = malloc(4 * sizeof(int *));
	i = -1;
	while (++i < 4)
	{
		tab[i] = malloc(4 * sizeof(int));
		j = -1;
		while (++j < 4)
			tab[i][j] = i * j;
	}
	return (tab);
}
```

With the fix, variables from `function` are hoisted in `function`:

```c
void	empty_function(void)
{
}

int	**function()
{
	int	**tab;
	int	i;
	int	j;

	tab = malloc(4 * sizeof(int *));
	i = -1;
	while (++i < 4)
	{
		tab[i] = malloc(4 * sizeof(int));
		j = -1;
		while (++j < 4)
			tab[i][j] = i * j;
	}
	return (tab);
}
```