### PR TITLE
Fix #50

### DIFF
--- a/tests/formatters/test_line_breaker.py
+++ b/tests/formatters/test_line_breaker.py
@@ -1,4 +1,3 @@
-# from c_formatter_42.formatters.line_breaker import line_breaker, indent_level
 from c_formatter_42.formatters.line_breaker import (
     additional_indent_level,
     indent_level,
@@ -220,7 +219,7 @@ def test_insert_line_break_basic_22():
 
 
 def test_insert_line_break_basic_23():
-    output = "foooooo(bar\n\t\t* baz)"
+    output = "foooooo(bar\n\t* baz)"
     assert output == line_breaker("foooooo(bar * baz)", 7)
 
 


### PR DESCRIPTION
Fixes #50 by properly calculating the additional indent level:

The previous code assumed a paren depth of 1 meant 2 tabs. This is incorrect and the code made a few exceptions for control statements and return statements to correct for this behavior. Of course, this couldn't catch all possible code where this adjustment was needed.

The new code assumes a paren depth of 1 means 1 tab. Tab count starts increasing once the paren depth is at least 2. (Had to check norminette's code to find this behavior, it wasn't fun)

---

Also fixed a test case that was based on the previous (incorrect) behavior (and it indeed made the norminette complain)

---

Finally, made a line of the code clearer and removed an unused comment at the top of the test file.

