### PR TITLE
Fix #51

### DIFF
--- a/c_formatter_42/data/.clang-format
+++ b/c_formatter_42/data/.clang-format
@@ -92,7 +92,7 @@ BreakBeforeTernaryOperators: true
 
 # ColumnLimit (unsigned)
 # The column limit.
-ColumnLimit: 0
+ColumnLimit: 1024
 
 
 # FixNamespaceComments (bool)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -55,6 +55,20 @@ def test_run_func_decl_single_tab_and_global_aligned():
     pass
 
 
+def test_run_long_aligned_func_decl():
+    # This function declaration is already aligned and should not be modified
+    input = """
+typedef struct s_foo
+{
+\tlong int\tbar;
+}\t\t\t\tt_foo;
+
+long int\t\tfoooooooooooooooooooooooooooooo(t_foo *foooooooo1,
+\t\t\t\t\tt_foo *foooooooo2, int barrrrrrrr1, int barrrrrrrr2);
+"""
+    assert input == run_all(input)
+
+
 def test_basic():
     input = """
 int main(int argc, char*argv[]){


### PR DESCRIPTION
Fixes #51 by setting Clang-Format's column limit to some large number to effectively "disable" it because `ColumnLimit: 0` was simply ignored, resulting in function declarations split up on multiple lines, which c_formatter_42 cannot handle, resulting in formatting errors.

On the topic of `ColumnLimit` getting ignored:
- https://stackoverflow.com/questions/47683910/can-you-set-clang-formats-line-length
- https://stackoverflow.com/questions/72911317/clang-format-does-not-honor-columnlimit-when-aligning-assignments
- https://github.com/llvm/llvm-project/issues/56444

I chose 1024 for the column limit since I think no reasonable code line would be over that threshold?