### PR TITLE
Fix #62

### DIFF
--- a/c_formatter_42/formatters/line_breaker.py
+++ b/c_formatter_42/formatters/line_breaker.py
@@ -20,6 +20,7 @@ def insert_break(line: str, column_limit: int) -> str:
     segments = line.split("\n")
 
     line_indent_level = indent_level(line)
+    nest_indent_level = additional_nest_indent_level(line)
 
     # Join as many segments as it doesn't exceed line length limit
     line = segments[0]
@@ -27,7 +28,9 @@ def insert_break(line: str, column_limit: int) -> str:
     for segment in segments[1:]:
         current_line_length += line_length(segment) + 1
         if current_line_length > column_limit:
-            tabulation = "\t" * (line_indent_level + additional_indent_level(line))
+            tabulation = "\t" * (
+                line_indent_level + additional_indent_level(line, nest_indent_level)
+            )
             line = ("\n" + tabulation).join([line, segment])
             current_line_length = line_length(tabulation + segment)
         else:
@@ -55,7 +58,7 @@ def insert_break(line: str, column_limit: int) -> str:
 #   (foo(bar()
 #   >   >   * baz()))       Next line should be indented with 2 tabs (paren depth is 2)
 #   -----------------------------------------------------------------------------------
-def additional_indent_level(s: str) -> int:
+def additional_indent_level(s: str, nest_indent_level: int = 0) -> int:
     paren_depth = 0
     is_surrounded_sq = False
     is_surrounded_dq = False
@@ -69,7 +72,21 @@ def additional_indent_level(s: str) -> int:
         elif c == ")" and not is_surrounded_sq and not is_surrounded_dq:
             paren_depth -= 1
 
-    return max(1, paren_depth)  # 1 is the default additional indent level
+    if paren_depth > 0:
+        return nest_indent_level + paren_depth
+    else:
+        return 1  # 1 is the default additional indent level
+
+
+def additional_nest_indent_level(line: str) -> int:
+    # An exceptional rule for variable assignment
+    # https://github.com/42School/norminette/blob/921b5e22d991591f385e1920f7e7ee5dcf71f3d5/norminette/rules/check_assignation_indent.py#L59
+    align_pattern = r"^\s*{name}\s+=\s+(.|\s)*?;$"
+    align_pattern = align_pattern.format(name=helper.REGEX_NAME)
+    if re.match(align_pattern, line):
+        return 1
+
+    return 0
 
 
 def line_length(line: str) -> int:
@@ -79,6 +96,7 @@ def line_length(line: str) -> int:
 
 def indent_level(line: str) -> int:
     # An exceptional rule for function declaration
+    # https://github.com/42School/norminette/blob/921b5e22d991591f385e1920f7e7ee5dcf71f3d5/norminette/rules/check_assignation_indent.py#L61
     align_pattern = r"^(static\s+)?{type}\s+{name}\((.|\s)*?\);"
     align_pattern = align_pattern.format(type=helper.REGEX_TYPE, name=helper.REGEX_NAME)
     if re.match(align_pattern, line):

--- a/tests/formatters/test_line_breaker.py
+++ b/tests/formatters/test_line_breaker.py
@@ -223,6 +223,16 @@ def test_insert_line_break_basic_23():
     assert output == line_breaker("foooooo(bar * baz)", 7)
 
 
+def test_insert_line_break_basic_24():
+    output = "*foo = foooooo(bar\n\t\t* baz);"
+    assert output == line_breaker("*foo = foooooo(bar * baz);", 18)
+
+
+def test_insert_line_break_basic_25():
+    output = "foo[0] = foooooo(bar\n\t\t* baz);"
+    assert output == line_breaker("foo[0] = foooooo(bar * baz);", 20)
+
+
 def test_insert_line_break_long_function_declaration():
     input = """
 static void\tst_merge_fields_in_curr(char *strs[3], t_tok_lst **curr, t_tok_lst *fields);


### PR DESCRIPTION
Fix variable assignment nesting indent

This is caused by some weird Norminette exception that variable assignments have one additional indent when nesting occurs. Don't ask me the reasoning behind this.....

