### PR TITLE
Fix #58

### DIFF
--- a/c_formatter_42/formatters/line_breaker.py
+++ b/c_formatter_42/formatters/line_breaker.py
@@ -79,7 +79,7 @@ def line_length(line: str) -> int:
 
 def indent_level(line: str) -> int:
     # An exceptional rule for function declaration
-    align_pattern = r"^(static\s+)?{type}\s+{name}\((.|\s)*?\);"
+    align_pattern = r"^(static\s+)?{type}\s+{name}\([^)]*?\);"
     align_pattern = align_pattern.format(type=helper.REGEX_TYPE, name=helper.REGEX_NAME)
     if re.match(align_pattern, line):
         last_tab_index = line.rfind("\t")


### PR DESCRIPTION
Fix #58 thanks to ChatGPT

Here's its answer:

The regex you've provided indeed contains a potential catastrophic backtracking issue. The problematic part is the `(.\|\s)*?` section within the regex. This part can lead to catastrophic backtracking when trying to match certain inputs, especially if the input contains a long sequence of characters followed by a semicolon.

Here's why it's problematic:
- `(.\|\s)*?` attempts to match any character or whitespace zero or more times in a non-greedy manner. The problem is that when the regex engine encounters a character that doesn't match, it will backtrack and try different ways of matching characters and whitespace until it either succeeds or exhausts all possibilities. This can lead to an exponential number of possible paths that the engine explores, causing significant slowdown or even freezing on certain inputs.

To avoid this issue, you can use a more specific pattern to match the content within the parentheses in a safer way. Here's a modified version of the regex that should help avoid catastrophic backtracking:

```python
r"^(static\s+)?{type}\s+{name}\([^)]*?\);"
```

In this modified regex, `[^)]*?` is used to match any sequence of characters except a closing parenthesis. This pattern ensures that the regex engine won't get stuck in catastrophic backtracking scenarios.