### PR TITLE
Fix long function declarations with parentheses in them

### DIFF
--- a/c_formatter_42/formatters/line_breaker.py
+++ b/c_formatter_42/formatters/line_breaker.py
@@ -81,7 +81,7 @@ def additional_indent_level(s: str, nest_indent_level: int = 0) -> int:
 def additional_nest_indent_level(line: str) -> int:
     # An exceptional rule for variable assignment
     # https://github.com/42School/norminette/blob/921b5e22d991591f385e1920f7e7ee5dcf71f3d5/norminette/rules/check_assignation_indent.py#L59
-    align_pattern = r"^\s*({decl})((\.|->){decl})*\s+=\s+[^;]*?;"
+    align_pattern = r"^\s*({decl})((\.|->){decl})*\s+=\s+(.|\n)*?;"
     align_pattern = align_pattern.format(decl=helper.REGEX_DECL_NAME)
     return 1 if re.match(align_pattern, line) is not None else 0
 
@@ -94,7 +94,7 @@ def line_length(line: str) -> int:
 def indent_level(line: str) -> int:
     # An exceptional rule for function declaration
     # https://github.com/42School/norminette/blob/921b5e22d991591f385e1920f7e7ee5dcf71f3d5/norminette/rules/check_assignation_indent.py#L61
-    align_pattern = r"^(static\s+)?{type}\s+{name}\([^)]*?\);"
+    align_pattern = r"^(static\s+)?{type}\s+{name}\((.|\n)*?\);$"
     align_pattern = align_pattern.format(type=helper.REGEX_TYPE, name=helper.REGEX_NAME)
     if re.match(align_pattern, line):
         last_tab_index = line.rfind("\t")

--- a/c_formatter_42/formatters/line_breaker.py
+++ b/c_formatter_42/formatters/line_breaker.py
@@ -81,7 +81,7 @@ def additional_indent_level(s: str, nest_indent_level: int = 0) -> int:
 def additional_nest_indent_level(line: str) -> int:
     # An exceptional rule for variable assignment
     # https://github.com/42School/norminette/blob/921b5e22d991591f385e1920f7e7ee5dcf71f3d5/norminette/rules/check_assignation_indent.py#L59
-    align_pattern = r"^\s*({decl})((\.|->){decl})*\s+=\s+(.|\n)*?;"
+    align_pattern = r"^\s*({decl})((\.|->){decl})*\s+=\s+(.|\n)*?;$"
     align_pattern = align_pattern.format(decl=helper.REGEX_DECL_NAME)
     return 1 if re.match(align_pattern, line) is not None else 0
 

--- a/tests/formatters/test_line_breaker.py
+++ b/tests/formatters/test_line_breaker.py
@@ -244,6 +244,17 @@ static void\tst_merge_fields_in_curr(char *strs[3], t_tok_lst **curr,
     assert line_breaker(input) == output
 
 
+def test_insert_line_break_long_function_declaration_with_parens():
+    input = """
+static void\tst_merge_fields_in_curr(char *strs[3], t_tok_lst **curr, void (*del)(void *));
+"""
+    output = """
+static void\tst_merge_fields_in_curr(char *strs[3], t_tok_lst **curr,
+\t\t\t\tvoid (*del)(void *));
+"""
+    assert line_breaker(input) == output
+
+
 def test_insert_line_break_control_statement_1():
     input = """\
 \twhile (true + false)


### PR DESCRIPTION
Turns out my fix for #58 from yesterday didn't take into account functions declarations with parens in them like this one:

```c
static void st_merge_fields_in_curr(char *strs[3], t_tok_lst **curr, void (*del)(void *));
```

This leads to the formatter not detecting them as func declarations and thus not indenting them properly

This fixes the regexes and I've ensured #58 stays fixed

~~_I blame ChatGPT!_~~