### PR TITLE
Line breaker: Fix variable assignation with cast

### DIFF
--- a/c_formatter_42/formatters/line_breaker.py
+++ b/c_formatter_42/formatters/line_breaker.py
@@ -44,9 +44,9 @@ def get_paren_depth(s: str) -> int:
     is_surrounded_sq = False
     is_surrounded_dq = False
     for c in s:
-        if c == "'":
+        if c == "'" and not is_surrounded_dq:
             is_surrounded_sq = not is_surrounded_sq
-        elif c == '"':
+        elif c == '"' and not is_surrounded_sq:
             is_surrounded_dq = not is_surrounded_dq
         elif c == "(" and not is_surrounded_sq and not is_surrounded_dq:
             paren_depth += 1
@@ -83,8 +83,21 @@ def additional_indent_level(s: str, nest_indent_level: int = 0) -> int:
 def additional_nest_indent_level(line: str) -> int:
     # An exceptional rule for variable assignment
     # https://github.com/42School/norminette/blob/921b5e22d991591f385e1920f7e7ee5dcf71f3d5/norminette/rules/check_assignation_indent.py#L59
-    parts = line.split("=")
-    is_assignation = len(parts) > 1 and get_paren_depth(parts[0]) == 0
+    index = 0
+    is_surrounded_sq = False
+    is_surrounded_dq = False
+    for c in line:
+        if c == "'" and not is_surrounded_dq:
+            is_surrounded_sq = not is_surrounded_sq
+        elif c == '"' and not is_surrounded_sq:
+            is_surrounded_dq = not is_surrounded_dq
+        elif c == "=" and not is_surrounded_sq and not is_surrounded_dq:
+            break
+        index += 1
+    if index == len(line):
+        return 0
+    var_name = line[:index].strip()
+    is_assignation = get_paren_depth(var_name) == 0
     return 1 if is_assignation else 0
 
 

--- a/c_formatter_42/formatters/line_breaker.py
+++ b/c_formatter_42/formatters/line_breaker.py
@@ -83,21 +83,23 @@ def additional_indent_level(s: str, nest_indent_level: int = 0) -> int:
 def additional_nest_indent_level(line: str) -> int:
     # An exceptional rule for variable assignment
     # https://github.com/42School/norminette/blob/921b5e22d991591f385e1920f7e7ee5dcf71f3d5/norminette/rules/check_assignation_indent.py#L59
-    index = 0
+    is_assignation = False
     is_surrounded_sq = False
     is_surrounded_dq = False
-    for c in line:
+    for index, c in enumerate(line):
         if c == "'" and not is_surrounded_dq:
             is_surrounded_sq = not is_surrounded_sq
         elif c == '"' and not is_surrounded_sq:
             is_surrounded_dq = not is_surrounded_dq
-        elif c == "=" and not is_surrounded_sq and not is_surrounded_dq:
+        is_assignation = (
+            c == "="
+            and not is_surrounded_sq
+            and not is_surrounded_dq
+            and get_paren_depth(line[:index]) == 0
+        )
+        if is_assignation:
             break
-        index += 1
-    if index == len(line):
-        return 0
-    var_name = line[:index].strip()
-    is_assignation = get_paren_depth(var_name) == 0
+
     return 1 if is_assignation else 0
 
 

--- a/tests/formatters/test_line_breaker.py
+++ b/tests/formatters/test_line_breaker.py
@@ -234,6 +234,11 @@ def test_insert_line_break_basic_25():
 
 
 def test_insert_line_break_basic_26():
+    output = '"EXT = TXT" + foooooo(bar\n\t* baz);'
+    assert output == line_breaker('"EXT = TXT" + foooooo(bar * baz);', 27)
+
+
+def test_insert_line_break_basic_27():
     input = (
         '((t_cast *)it->content)->name = get_name((t_cast *)it->content, "EXT=TXT");'
     )

--- a/tests/formatters/test_line_breaker.py
+++ b/tests/formatters/test_line_breaker.py
@@ -224,13 +224,22 @@ def test_insert_line_break_basic_23():
 
 
 def test_insert_line_break_basic_24():
-    output = "*foo = foooooo(bar\n\t\t* baz);"
-    assert output == line_breaker("*foo = foooooo(bar * baz);", 18)
+    output = "foo = foooooo(bar\n\t\t* baz);"
+    assert output == line_breaker("foo = foooooo(bar * baz);", 18)
 
 
 def test_insert_line_break_basic_25():
-    output = "foo[0] = foooooo(bar\n\t\t* baz);"
-    assert output == line_breaker("foo[0] = foooooo(bar * baz);", 20)
+    output = "foo[i] = foooooo(bar\n\t\t* baz);"
+    assert output == line_breaker("foo[i] = foooooo(bar * baz);", 21)
+
+
+def test_insert_line_break_basic_26():
+    input = (
+        '((t_cast *)it->content)->name = get_name((t_cast *)it->content, "EXT=TXT");'
+    )
+    output = """((t_cast *)it->content)->name = get_name((t_cast *)it->content,
+\t\t\"EXT=TXT\");"""
+    assert output == line_breaker(input, 64)
 
 
 def test_insert_line_break_long_function_declaration():


### PR DESCRIPTION
The current regex doesn't take into account variable assignments with casting (e.g. `(type)var = value;`)

Implementing a regex to match all cases (e.g. `(type)var`, `(type) var`, `(type)(var)`, `(type)(var->value)->value`) would probably result in an illegible regex.

I've modified the code to match any line like `txt = txt`. It checks that the equal sign is not within parens (like for `while (var = value)`) and that it isn't in a string.

I've added test cases and used it to format all files in my minishell project with great success.

Let me know if the code needs anything changed.
