### PR TITLE
Fix: Enable fallback to system clang-format for Linux ARM64 (and others)  (#87)

### DIFF
--- a/c_formatter_42/formatters/clang_format.py
+++ b/c_formatter_42/formatters/clang_format.py
@@ -45,20 +45,23 @@ def _config_context():
             CONFIG_FILENAME.write_text(previous_config)
 
 
-if sys.platform == "linux":
-    CLANG_FORMAT_EXEC = DATA_DIR / "clang-format-linux"
-elif sys.platform == "darwin":
-    if platform.machine() == "arm64":
-        # macOS M1 or Apple Silicon
-        CLANG_FORMAT_EXEC = DATA_DIR / "clang-format-darwin-arm64"
-    elif platform.machine() == "x86_64":
-        # macOS Intel
-        CLANG_FORMAT_EXEC = DATA_DIR / "clang-format-darwin"
-elif sys.platform == "win32":
-    CLANG_FORMAT_EXEC = DATA_DIR / "clang-format-win32.exe"
-else:
-    raise NotImplementedError("Your platform is not supported")
 
+BINARY_MAP = {
+    ("linux", "aarch64"): "/usr/bin/clang-format",
+    ("linux", "arm64"):   "/usr/bin/clang-format",
+    ("linux", "x86_64"):  DATA_DIR / "clang-format-linux",
+    ("darwin", "arm64"):  DATA_DIR / "clang-format-darwin-arm64",
+    ("darwin", "x86_64"): DATA_DIR / "clang-format-darwin",
+    ("win32", "AMD64"):   DATA_DIR / "clang-format-win32.exe",
+    ("win32", "x86_64"):  DATA_DIR / "clang-format-win32.exe",
+}
+
+system_key = (sys.platform, platform.machine())
+
+CLANG_FORMAT_EXEC = BINARY_MAP.get(system_key)
+
+if not CLANG_FORMAT_EXEC:
+    raise NotImplementedError(f"Platform {system_key} is not supported")
 
 def clang_format(content: str) -> str:
     """Wrapper around clang-format

--- a/c_formatter_42/formatters/clang_format.py
+++ b/c_formatter_42/formatters/clang_format.py
@@ -75,7 +75,7 @@ def get_clang_format_path() -> str:
     )
 
 
-#Set var to result of search:
+# Set var to result of search
 CLANG_FORMAT_EXEC = get_clang_format_path()
 
 

--- a/c_formatter_42/formatters/clang_format.py
+++ b/c_formatter_42/formatters/clang_format.py
@@ -6,7 +6,7 @@
 #    By: cacharle <me@cacharle.xyz>                 +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/10/04 10:40:07 by cacharle          #+#    #+#              #
-#    Updated: 2021/02/25 20:46:18 by cacharle         ###   ########.fr        #
+#    Updated: 2026/01/11 22:21:42 by lrain            ###   ########.fr        #
 #                                                                              #
 # ############################################################################ #
 
@@ -69,7 +69,7 @@ if CLANG_FORMAT_EXEC is None:
 # error if neither found
 if CLANG_FORMAT_EXEC is None:
     raise NotImplementedError(
-        f"Platform {system_key} is not supported and 'clang-format' "
+        f"Platform {system_key} isn't offically supported and 'clang-format' "
         "was not found in your PATH."
     )
 

--- a/c_formatter_42/formatters/clang_format.py
+++ b/c_formatter_42/formatters/clang_format.py
@@ -45,10 +45,11 @@ def _config_context():
             CONFIG_FILENAME.write_text(previous_config)
 
 
+SYSTEM_CLANG_FORMAT = shutil.which("clang-format")
 
 BINARY_MAP = {
-    ("linux", "aarch64"): "/usr/bin/clang-format",
-    ("linux", "arm64"):   "/usr/bin/clang-format",
+    ("linux", "aarch64"): "SYSTEM_CLANG_FORMAT",
+    ("linux", "arm64"):   "SYSTEM_CLANG_FORMAT",
     ("linux", "x86_64"):  DATA_DIR / "clang-format-linux",
     ("darwin", "arm64"):  DATA_DIR / "clang-format-darwin-arm64",
     ("darwin", "x86_64"): DATA_DIR / "clang-format-darwin",
@@ -61,6 +62,8 @@ system_key = (sys.platform, platform.machine())
 CLANG_FORMAT_EXEC = BINARY_MAP.get(system_key)
 
 if not CLANG_FORMAT_EXEC:
+    if system_key[0] == "linux" and system_key[1] in ["aarch64", "arm64"]:
+            raise FileNotFoundError("No clang-format installation found")
     raise NotImplementedError(f"Platform {system_key} is not supported")
 
 def clang_format(content: str) -> str:

--- a/c_formatter_42/formatters/clang_format.py
+++ b/c_formatter_42/formatters/clang_format.py
@@ -75,7 +75,7 @@ def get_clang_format_path() -> str:
     )
 
 
-# Now your main logic is just one clean line:
+#Set var to result of search:
 CLANG_FORMAT_EXEC = get_clang_format_path()
 
 


### PR DESCRIPTION
This PR
- replaces the if statements with lookup dictionary with explicit  OS and architecture values
- searches the system for a locally installed version of clang-format as a fallback
- errors out if either doesn't yield any results

this should provide a solution for #87  while allowing for future binaries to be added to the lookup . It should also provide a solution for BSD or any other system that can make use of `shutil.which("clang-format")` but doesn't have a clang-format binary provided by c_formatter_42 yet.